### PR TITLE
Add zh-Hant lang to cjk-punc

### DIFF
--- a/assets/tategaki.css
+++ b/assets/tategaki.css
@@ -79,6 +79,20 @@
     font-feature-settings: "vhal" 0;
 }
 
-.firefox .squeeze-other-punc:last-child {
-    text-combine-upright: all;
+.safari .squeeze-other-punc {
+    font-feature-settings: 'locl';
+}
+
+.chrome .squeeze-other-punc:only-child,
+.firefox .cjk-punc:last-child .squeeze-other-punc:last-child {
+    margin-top: -1rem;
+    margin-bottom: -1rem;
+}
+
+.chrome .squeeze-other-punc:only-child::before,
+.chrome .squeeze-other-punc:only-child::after,
+.firefox .cjk-punc:last-child .squeeze-other-punc:last-child::before,
+.firefox .cjk-punc:last-child .squeeze-other-punc:last-child::after {
+    content: '〇';
+    opacity: 0;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tategaki",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Transform HTML elements into vertical writing (Tategaki)",
   "main": "dist/tategaki.cjs.js",
   "module": "dist/tategaki.es.js",

--- a/src/tategaki.ts
+++ b/src/tategaki.ts
@@ -48,6 +48,7 @@ export class Tategaki {
             }
             case StringFormatGuide.cjkPunc: {
                 if (this.config.shouldPcS) {
+                    element.setAttribute('lang', 'zh-Hant')
                     element.innerHTML = this.squeeze(segment.content)
                 }
                 break

--- a/src/tategaki.ts
+++ b/src/tategaki.ts
@@ -48,7 +48,6 @@ export class Tategaki {
             }
             case StringFormatGuide.cjkPunc: {
                 if (this.config.shouldPcS) {
-                    element.setAttribute('lang', 'zh-Hant')
                     element.innerHTML = this.squeeze(segment.content)
                 }
                 break


### PR DESCRIPTION
This is the best solution for CJK punc right now. For simple Chinese rendering, CJK punc is not centered, this will cause many rendering issues.

Comma on Firefox is left aligned, period on Firefox is centered:

![image](https://user-images.githubusercontent.com/290496/138206648-39072292-f7c9-46dd-aca5-e0ce470aa758.png)

Comma on Chrome is right aligned, period on Chrome is right aligned:

![image](https://user-images.githubusercontent.com/290496/138206710-fe95d9ab-33f5-4fd9-a811-115371c8d1e6.png)


With `lang=zh-Hant`, everything will be centered.